### PR TITLE
Sidebar close/open tag

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -285,7 +285,7 @@ main.hidden {
   padding: 10px;
   position: absolute;
   bottom: 0;
-  left: 0;
+  left: 300px;
   text-align: center;
   transition: opacity 0.3s;
   width: 284px;

--- a/docs/style.css
+++ b/docs/style.css
@@ -406,6 +406,7 @@ body.close .sidebar {
 }
 body.close .sidebar-toggle {
   width: auto;
+  left: auto;
 }
 body.close .content {
   left: 0;


### PR DESCRIPTION
the tag was hidden on the text being overlap. I positioned it 300px to the left to be place just outside of the sidebar. and when you toggle it close it will left auto positioned. 