### PR TITLE
Added instructions for connecting to Github

### DIFF
--- a/docs/github/connecting.md
+++ b/docs/github/connecting.md
@@ -1,1 +1,37 @@
-1. Connecting to GitHub
+# Connecting to GitHub
+
+> NOTE: I do not own any paid version of FlutterFlow, so I am going off of what I have been able to see in screenshots and Youtube videos.
+
+> This guide assumes basic knowledge of github. To learn how to get started with github, click [HERE.](https://docs.github.com/en/get-started)
+
+### Step 1
+
+The first step in connecting to github is making a new repository. This is pretty self explanatory.
+
+### Step 2
+
+Next, you must install the [FlutterFlow Github App.](https://github.com/apps/flutterflow-github-app)
+
+To do this, click the green "Install" button, click "Only Select Repositories," and choose the repository you just made.
+
+Once this is done, click "Install" and confirm your pasword.
+
+### Step 3
+
+Now, you must go back to your repository, and copy the url to it.
+
+### Step 4
+
+After you do this, go back to FlutterFlow, paste the url into the "Github Configuration" tab (under "Settings and Integrations" in the sidebar) and press "Associate Repo." A popup should appear saying "Success!" and the button should now read "Remove Repo."
+
+### Step 5
+
+Now, at the top of the "Github Configuration Tab" in FlutterFlow, you can press the blue button that says "Push to Repository" in order to push the code directly from FlutterFlow into your Github repository. A turquoise popup should appear saying "Success!"
+
+### Step 6
+
+Go back to your Github Repository and refresh the page. Don't be alarmed, as you probably don't see  any code yet. To see the code, you must change the branch to the one titled "FlutterFlow." This can be done by pressing the dropdown towards the top, labeled "Main," and clicking "FlutterFlow" from the list that comes down.
+
+### Step 7
+
+Congratulations! You just connected your FlutterFlow app to a Github Repository!


### PR DESCRIPTION
I added written instructions into docs/github/connecting.md, since all of your Github documentation is empty. You will probably have to switch the "Github Version Control" tab in [the FlutterFlow docs](docs.flutterflow.io) to connecting.md from intro.md, however. 

Please note that I don't own any paid version of FlutterFlow, so these instructions may not be perfect. Please suggest changes if anything is wrong.