### PR TITLE
Added previewing steps

### DIFF
--- a/docs/deployment/previewing.md
+++ b/docs/deployment/previewing.md
@@ -1,1 +1,5 @@
-1. Previewing your app
+# Previewing Your App
+
+Previewing your app has never been easier! All you have to do is click the Orange "Preview" button at the top right of your screen! 
+
+> There are some known limitations, such as Firestore data not loading, Firebase auth not working, API calls not working, and TextField validation not working, but all of these can be avoided when using run mode.


### PR DESCRIPTION
Added previewing steps, but I can't download, so somebody else will have to fill those steps in. I'm also not sure what is meant by sharing...Teams? There is no visible way to share the app other than downloading the apk. The only mention of it is a checked box labaled "share mode" in the settings and integrations tab.